### PR TITLE
yubikey-piv v0.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,35 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.3] (2019-12-02)
+### Added
+- Initial `Readers` enumerator for detecting YubiKeys ([#51])
+- Certificate parsing ([#45])
+
+### Changed
+- Use `Reader` to connect to `YubiKey` ([#51])
+- Convert `SlotId` and `AlgorithmId` into enums ([#44])
+- Use `secrecy` crate for storing `CachedPin` ([#43])
+- Change `CHUID` struct to hold complete CHUID value ([#42])
+- Eliminate all usages of `unsafe` ([#37], [#39])
+- Make anonymous CHUID struct public ([#36])
+- Have `sign_data` and `decrypt_data` return a `Buffer` ([#34])
+- `Ins` (APDU instruction codes) enum ([#33])
+- Factor `Response` into `apdu` module; improved debugging ([#32])
+
+[0.0.3]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/53
+[#51]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/51
+[#45]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/45
+[#44]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/44
+[#43]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/43
+[#42]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/42
+[#39]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/39
+[#37]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/37
+[#36]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/36
+[#34]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/34
+[#33]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/33
+[#32]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/32
+
 ## [0.0.2] (2019-11-25)
 ### Added
 - `untested` Cargo feature to mark untested functionality ([#30])

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -842,12 +842,12 @@ dependencies = [
  "gumdrop 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "termcolor 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "yubikey-piv 0.0.2",
+ "yubikey-piv 0.0.3",
 ]
 
 [[package]]
 name = "yubikey-piv"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "der-parser 3.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "des 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "yubikey-piv"
-version = "0.0.2" # Also update html_root_url in lib.rs when bumping this
+version = "0.0.3" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust host-side driver for the YubiKey Personal Identity Verification (PIV)
 application providing general-purpose public-key signing and encryption

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -18,4 +18,4 @@ gumdrop = "0.7"
 env_logger = "0.7"
 lazy_static = "1"
 termcolor = "1"
-yubikey-piv = { version = "0.0.2", path = ".." }
+yubikey-piv = { version = "0.0.3", path = ".." }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,7 +123,7 @@
 
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tarcieri/yubikey-piv.rs/develop/img/logo.png",
-    html_root_url = "https://docs.rs/yubikey-piv/0.0.2"
+    html_root_url = "https://docs.rs/yubikey-piv/0.0.3"
 )]
 #![forbid(unsafe_code)]
 #![warn(


### PR DESCRIPTION
### Added
- Initial `Readers` enumerator for detecting YubiKeys ([#51])
- Certificate parsing ([#45])

### Changed
- Use `Reader` to connect to `YubiKey` ([#51])
- Convert `SlotId` and `AlgorithmId` into enums ([#44])
- Use `secrecy` crate for storing `CachedPin` ([#43])
- Change `CHUID` struct to hold complete CHUID value ([#42])
- Eliminate all usages of `unsafe` ([#37], [#39])
- Make anonymous CHUID struct public ([#36])
- Have `sign_data` and `decrypt_data` return a `Buffer` ([#34])
- `Ins` (APDU instruction codes) enum ([#33])
- Factor `Response` into `apdu` module; improved debugging ([#32])

[#51]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/51
[#45]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/45
[#44]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/44
[#43]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/43
[#42]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/42
[#39]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/39
[#37]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/37
[#36]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/36
[#34]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/34
[#33]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/33
[#32]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/32