### PR TITLE
CCCID/CHUID tests and cleanups

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,13 +65,13 @@ functions of the YubiKey:
 |    | Module        | Issue | Description |
 |----|---------------|-------|-------------|
 | 🚧 | `yubikey`     | [#20] | Core functionality: auth, keys, PIN/PUK, encrypt, sign, attest |
-| ⚠️ | `cccid`       | [#21] | Cardholder Capability Container (CCC) IDs |
+| 🚧 | `cccid`       | [#21] | Cardholder Capability Container (CCC) IDs |
 | 🚧️ | `certificate` | [#22] | Certificates for stored keys |
-| ⚠️ | `chuid`       | [#23] | Cardholder Unique Identifier (CHUID) |
+| 🚧 | `chuid`       | [#23] | Cardholder Unique Identifier (CHUID) |
 | ✅️ | `config`      | [#24] | Support for reading on-key configuration |
 | ⚠️ | `container`   | [#25] | MS Container Map Records |
 | 🚧 | `key`         | [#26] | Crypto key management: list, generate, import |
-| ⚠️ | `mgm`         | [#26] | Management Key (MGM) support: set, get, derive |
+| 🚧 | `mgm`         | [#26] | Management Key (MGM) support: set, get, derive |
 | ⚠️ | `msroots`     | [#28] | `msroots` file: PKCS#7 formatted certificate store for enterprise trusted roots |
 
 Legend:

--- a/src/cccid.rs
+++ b/src/cccid.rs
@@ -48,27 +48,29 @@ const CCC_TMPL: &[u8] = &[
     0x00, 0xfe, 0x00,
 ];
 
-/// Cardholder Capability Container (CCC) Identifier card ID
+/// Cardholder Capability Container (CCC) Identifier Card ID
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
-pub struct CccCardId(pub [u8; YKPIV_CCCID_SIZE]);
+pub struct CardId(pub [u8; YKPIV_CCCID_SIZE]);
+
+impl CardId {
+    /// Generate a random CCC Card ID
+    pub fn generate() -> Result<Self, Error> {
+        let mut id = [0u8; YKPIV_CCCID_SIZE];
+        getrandom(&mut id).map_err(|_| Error::RandomnessError)?;
+        Ok(Self(id))
+    }
+}
 
 /// Cardholder Capability Container (CCC) Identifier
 #[derive(Copy, Clone)]
 pub struct CCC(pub [u8; YKPIV_CCC_SIZE]);
 
 impl CCC {
-    /// Return CardId component of CHUID
-    pub fn cccid(&self) -> Result<CccCardId, Error> {
+    /// Return CardId component of CCC
+    pub fn cccid(&self) -> Result<CardId, Error> {
         let mut cccid = [0u8; YKPIV_CCCID_SIZE];
         cccid.copy_from_slice(&self.0[CCC_ID_OFFS..(CCC_ID_OFFS + YKPIV_CCCID_SIZE)]);
-        Ok(CccCardId(cccid))
-    }
-
-    /// Generate a random CCCID
-    pub fn generate() -> Result<CccCardId, Error> {
-        let mut id = [0u8; YKPIV_CCCID_SIZE];
-        getrandom(&mut id).map_err(|_| Error::RandomnessError)?;
-        Ok(CccCardId(id))
+        Ok(CardId(cccid))
     }
 
     /// Get Cardholder Capability Container (CCC) ID
@@ -82,7 +84,7 @@ impl CCC {
 
         let mut ccc = [0u8; YKPIV_CCC_SIZE];
         ccc.copy_from_slice(&response[0..YKPIV_CCC_SIZE]);
-        Ok(CCC { 0: ccc })
+        Ok(Self(ccc))
     }
 
     /// Get Cardholder Capability Container (CCC) ID

--- a/src/chuid.rs
+++ b/src/chuid.rs
@@ -57,7 +57,16 @@ const CHUID_TMPL: &[u8] = &[
 
 /// Cardholder Unique Identifier (CHUID) Card UUID/GUID value
 #[derive(Copy, Clone, Debug)]
-pub struct ChuidUuid(pub [u8; YKPIV_CARDID_SIZE]);
+pub struct Uuid(pub [u8; YKPIV_CARDID_SIZE]);
+
+impl Uuid {
+    /// Generate a random Cardholder Unique Identifier (CHUID)
+    pub fn generate() -> Result<Self, Error> {
+        let mut id = [0u8; YKPIV_CARDID_SIZE];
+        getrandom(&mut id).map_err(|_| Error::RandomnessError)?;
+        Ok(Self(id))
+    }
+}
 
 /// Cardholder Unique Identifier (CHUID)
 #[derive(Copy, Clone)]
@@ -85,13 +94,6 @@ impl CHUID {
             &self.0[CHUID_EXPIRATION_OFFS..(CHUID_EXPIRATION_OFFS + YKPIV_EXPIRATION_SIZE)],
         );
         Ok(expiration)
-    }
-
-    /// Generate a random Cardholder Unique Identifier (CHUID)
-    pub fn generate() -> Result<ChuidUuid, Error> {
-        let mut id = [0u8; YKPIV_CARDID_SIZE];
-        getrandom(&mut id).map_err(|_| Error::RandomnessError)?;
-        Ok(ChuidUuid(id))
     }
 
     /// Get Cardholder Unique Identifier (CHUID)

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -67,12 +67,6 @@ pub const CB_OBJ_TAG_MAX: usize = (CB_OBJ_TAG_MIN + 2); // 1 byte tag + 3 bytes 
 pub const CB_PAGE: usize = 4096;
 pub const CB_PIN_MAX: usize = 8;
 
-pub const CCC_ID_OFFS: usize = 9;
-
-pub const CHUID_FASCN_OFFS: usize = 2;
-pub const CHUID_GUID_OFFS: usize = 29;
-pub const CHUID_EXPIRATION_OFFS: usize = 47;
-
 pub const CHREF_ACT_CHANGE_PIN: i32 = 0;
 pub const CHREF_ACT_UNBLOCK_PIN: i32 = 1;
 pub const CHREF_ACT_CHANGE_PUK: i32 = 2;
@@ -128,21 +122,11 @@ pub const TAG_ECC_POINT: u8 = 0x86;
 
 pub const YKPIV_ALGO_3DES: u8 = 0x03;
 
-pub const YKPIV_CHUID_SIZE: usize = 59;
-pub const YKPIV_CARDID_SIZE: usize = 16;
-pub const YKPIV_FASCN_SIZE: usize = 25;
-pub const YKPIV_EXPIRATION_SIZE: usize = 8;
-
-pub const YKPIV_CCCID_SIZE: usize = 14;
-pub const YKPIV_CCC_SIZE: usize = 51;
-
 pub const YKPIV_CERTINFO_UNCOMPRESSED: u8 = 0;
 pub const YKPIV_CERTINFO_GZIP: u8 = 1;
 
 pub const YKPIV_KEY_CARDMGM: u8 = 0x9b;
 
-pub const YKPIV_OBJ_CAPABILITY: u32 = 0x005f_c107;
-pub const YKPIV_OBJ_CHUID: u32 = 0x005f_c102;
 pub const YKPIV_OBJ_FINGERPRINTS: u32 = 0x005f_c103;
 pub const YKPIV_OBJ_SECURITY: u32 = 0x005f_c106;
 pub const YKPIV_OBJ_FACIAL: u32 = 0x005f_c108;

--- a/src/error.rs
+++ b/src/error.rs
@@ -88,6 +88,9 @@ pub enum Error {
 
     /// Not supported
     NotSupported,
+
+    /// Not found
+    NotFound,
 }
 
 impl Error {
@@ -113,6 +116,7 @@ impl Error {
             Error::ArgumentError => "YKPIV_ARGUMENT_ERROR",
             Error::RangeError => "YKPIV_RANGE_ERROR",
             Error::NotSupported => "YKPIV_NOT_SUPPORTED",
+            Error::NotFound => "<not found>",
         }
     }
 
@@ -135,6 +139,7 @@ impl Error {
             Error::ArgumentError => "argument error",
             Error::RangeError => "range error",
             Error::NotSupported => "not supported",
+            Error::NotFound => "not found",
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,10 +136,8 @@
 )]
 
 mod apdu;
-#[cfg(feature = "untested")]
 pub mod cccid;
 pub mod certificate;
-#[cfg(feature = "untested")]
 pub mod chuid;
 pub mod config;
 pub mod consts;
@@ -159,10 +157,7 @@ pub mod settings;
 mod transaction;
 pub mod yubikey;
 
-pub use self::{readers::Readers, yubikey::YubiKey};
-
-#[cfg(feature = "untested")]
-pub use self::{key::Key, mgm::MgmKey};
+pub use self::{error::Error, key::Key, mgm::MgmKey, readers::Readers, yubikey::YubiKey};
 
 /// Object identifiers
 pub type ObjectId = u32;

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -448,7 +448,11 @@ impl<'tx> Transaction<'tx> {
         let response = self.transfer_data(&templ, &indata[..inlen], CB_BUF_MAX)?;
 
         if !response.is_success() {
-            return Err(Error::GenericError);
+            if response.status_words() == StatusWords::NotFoundError {
+                return Err(Error::NotFound);
+            } else {
+                return Err(Error::GenericError);
+            }
         }
 
         let data = Buffer::new(response.data().into());

--- a/src/yubikey.rs
+++ b/src/yubikey.rs
@@ -155,6 +155,9 @@ impl YubiKey {
         Err(Error::GenericError)
     }
 
+    /// Open a connection to a YubiKey with the given serial number.
+
+
     /// Reconnect to a YubiKey
     #[cfg(feature = "untested")]
     pub fn reconnect(&mut self) -> Result<(), Error> {

--- a/src/yubikey.rs
+++ b/src/yubikey.rs
@@ -31,6 +31,8 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use crate::{
+    cccid::CCC,
+    chuid::CHUID,
     config::Config,
     error::Error,
     readers::{Reader, Readers},
@@ -152,11 +154,8 @@ impl YubiKey {
         }
 
         error!("no YubiKey detected!");
-        Err(Error::GenericError)
+        Err(Error::NotFound)
     }
-
-    /// Open a connection to a YubiKey with the given serial number.
-
 
     /// Reconnect to a YubiKey
     #[cfg(feature = "untested")]
@@ -207,6 +206,16 @@ impl YubiKey {
     /// Get device configuration.
     pub fn config(&mut self) -> Result<Config, Error> {
         Config::get(self)
+    }
+
+    /// Get CHUID
+    pub fn chuid(&mut self) -> Result<CHUID, Error> {
+        CHUID::get(self)
+    }
+
+    /// Get CCCID
+    pub fn cccid(&mut self) -> Result<CCC, Error> {
+        CCC::get(self)
     }
 
     /// Authenticate to the card using the provided management key (MGM).

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -6,7 +6,7 @@
 use lazy_static::lazy_static;
 use log::trace;
 use std::{env, sync::Mutex};
-use yubikey_piv::{key::Key, YubiKey};
+use yubikey_piv::{key::Key, Error, YubiKey};
 
 lazy_static! {
     /// Provide thread-safe access to a YubiKey
@@ -25,6 +25,38 @@ fn init_yubikey() -> Mutex<YubiKey> {
     trace!("version: {}", yubikey.version());
 
     Mutex::new(yubikey)
+}
+
+//
+// CCCID support
+//
+
+#[test]
+#[ignore]
+fn test_get_cccid() {
+    let mut yubikey = YUBIKEY.lock().unwrap();
+
+    match yubikey.cccid() {
+        Ok(cccid) => trace!("CCCID: {:?}", cccid),
+        Err(Error::NotFound) => trace!("CCCID not found"),
+        Err(err) => panic!("error getting CCCID: {:?}", err),
+    }
+}
+
+//
+// CHUID support
+//
+
+#[test]
+#[ignore]
+fn test_get_chuid() {
+    let mut yubikey = YUBIKEY.lock().unwrap();
+
+    match yubikey.chuid() {
+        Ok(chuid) => trace!("CHUID: {:?}", chuid),
+        Err(Error::NotFound) => trace!("CHUID not found"),
+        Err(err) => panic!("error getting CHUID: {:?}", err),
+    }
 }
 
 //


### PR DESCRIPTION
 - Move generate methods to the appropriate static types
- Remove redundant name prefixes (Rust [RFC#356])
- Adds tests for CCCID/CHUID, allowing not found (is that ok?)
- Move constants under their respective modules and remove `YKPIV_`

[RFC#356]: https://github.com/rust-lang/rfcs/pull/356