### PR TITLE
Finish eliminating `consts` module

### DIFF
--- a/src/certificate.rs
+++ b/src/certificate.rs
@@ -31,13 +31,12 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use crate::{
-    consts::*,
     error::Error,
     key::{AlgorithmId, SlotId},
     serialization::*,
     transaction::Transaction,
     yubikey::YubiKey,
-    Buffer,
+    Buffer, CB_OBJ_TAG_MIN,
 };
 use elliptic_curve::weierstrass::{
     curve::{NistP256, NistP384},
@@ -49,6 +48,9 @@ use std::fmt;
 use x509_parser::{parse_x509_der, x509::SubjectPublicKeyInfo};
 use zeroize::Zeroizing;
 
+#[cfg(feature = "untested")]
+use crate::CB_OBJ_MAX;
+
 // TODO: Make these der_parser::oid::Oid constants when it has const fn support.
 const OID_RSA_ENCRYPTION: &str = "1.2.840.113549.1.1.1";
 const OID_EC_PUBLIC_KEY: &str = "1.2.840.10045.2.1";
@@ -59,6 +61,12 @@ const OID_NIST_P384: &str = "1.3.132.0.34";
 const CERTINFO_UNCOMPRESSED: u8 = 0;
 #[cfg(feature = "untested")]
 const CERTINFO_GZIP: u8 = 1;
+
+const TAG_CERT: u8 = 0x70;
+#[cfg(feature = "untested")]
+const TAG_CERT_COMPRESS: u8 = 0x71;
+#[cfg(feature = "untested")]
+const TAG_CERT_LRC: u8 = 0xFE;
 
 /// Information about a public key within a [`Certificate`].
 #[derive(Clone, Eq, PartialEq)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -30,7 +30,14 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::{consts::*, error::Error, metadata, mgm::MgmType, yubikey::YubiKey};
+use crate::{
+    error::Error,
+    metadata,
+    mgm::{MgmType, ADMIN_FLAGS_1_PROTECTED_MGM},
+    yubikey::{YubiKey, ADMIN_FLAGS_1_PUK_BLOCKED},
+    TAG_ADMIN, TAG_ADMIN_FLAGS_1, TAG_ADMIN_SALT, TAG_ADMIN_TIMESTAMP, TAG_PROTECTED,
+    TAG_PROTECTED_FLAGS_1, TAG_PROTECTED_MGM,
+};
 use log::error;
 use std::{
     convert::TryInto,

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -35,29 +35,7 @@
 #![allow(missing_docs, non_upper_case_globals)]
 #![cfg_attr(not(feature = "untested"), allow(dead_code))]
 
-pub const ADMIN_FLAGS_1_PUK_BLOCKED: u8 = 0x01;
-pub const ADMIN_FLAGS_1_PROTECTED_MGM: u8 = 0x02;
 
-pub const CB_BUF_MAX: usize = 3072;
 
-pub const CB_OBJ_MAX: usize = CB_BUF_MAX - 9;
-pub const CB_OBJ_TAG_MIN: usize = 2; // 1 byte tag + 1 byte len
-pub const CB_OBJ_TAG_MAX: usize = (CB_OBJ_TAG_MIN + 2); // 1 byte tag + 3 bytes len
 
-pub const TAG_CERT: u8 = 0x70;
-pub const TAG_CERT_COMPRESS: u8 = 0x71;
-pub const TAG_CERT_LRC: u8 = 0xFE;
-pub const TAG_ADMIN: u8 = 0x80;
-pub const TAG_ADMIN_FLAGS_1: u8 = 0x81;
-pub const TAG_ADMIN_SALT: u8 = 0x82;
-pub const TAG_ADMIN_TIMESTAMP: u8 = 0x83;
-pub const TAG_PROTECTED: u8 = 0x88;
-pub const TAG_PROTECTED_FLAGS_1: u8 = 0x81;
-pub const TAG_PROTECTED_MGM: u8 = 0x89;
-pub const TAG_MSCMAP: u8 = 0x81;
-pub const TAG_MSROOTS_END: u8 = 0x82;
-pub const TAG_MSROOTS_MID: u8 = 0x83;
 
-pub const TAG_RSA_MODULUS: u8 = 0x81;
-pub const TAG_RSA_EXP: u8 = 0x82;
-pub const TAG_ECC_POINT: u8 = 0x86;

--- a/src/container.rs
+++ b/src/container.rs
@@ -33,7 +33,9 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::{consts::*, error::Error, key::SlotId, serialization::*, yubikey::YubiKey};
+use crate::{
+    error::Error, key::SlotId, serialization::*, yubikey::YubiKey, CB_OBJ_MAX, CB_OBJ_TAG_MIN,
+};
 use log::error;
 use std::{
     convert::{TryFrom, TryInto},
@@ -47,6 +49,8 @@ const CONTAINER_NAME_LEN: usize = 40;
 const CONTAINER_REC_LEN: usize = (2 * CONTAINER_NAME_LEN) + 27;
 
 const OBJ_MSCMAP: u32 = 0x005f_ff10;
+
+const TAG_MSCMAP: u8 = 0x81;
 
 /// MS Container Map(?) Records
 #[derive(Copy, Clone)]

--- a/src/key.rs
+++ b/src/key.rs
@@ -49,10 +49,9 @@ use std::convert::TryFrom;
 #[cfg(feature = "untested")]
 use crate::{
     apdu::{Ins, StatusWords},
-    consts::*,
     policy::{PinPolicy, TouchPolicy},
     serialization::*,
-    settings, Buffer,
+    settings, Buffer, CB_OBJ_MAX,
 };
 #[cfg(feature = "untested")]
 use log::{error, warn};
@@ -63,6 +62,13 @@ use zeroize::Zeroizing;
 const CB_ECC_POINTP256: usize = 65;
 #[cfg(feature = "untested")]
 const CB_ECC_POINTP384: usize = 97;
+
+#[cfg(feature = "untested")]
+const TAG_RSA_MODULUS: u8 = 0x81;
+#[cfg(feature = "untested")]
+const TAG_RSA_EXP: u8 = 0x82;
+#[cfg(feature = "untested")]
+const TAG_ECC_POINT: u8 = 0x86;
 
 /// Slot identifiers.
 /// <https://developers.yubico.com/PIV/Introduction/Certificate_slots.html>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,7 +140,6 @@ pub mod cccid;
 pub mod certificate;
 pub mod chuid;
 pub mod config;
-mod consts;
 #[cfg(feature = "untested")]
 pub mod container;
 pub mod error;
@@ -164,3 +163,32 @@ pub type ObjectId = u32;
 
 /// Buffer type (self-zeroizing byte vector)
 pub(crate) type Buffer = zeroize::Zeroizing<Vec<u8>>;
+
+/// YubiKey max buffer size
+pub(crate) const CB_BUF_MAX: usize = 3072;
+
+/// YubiKey max object size
+#[cfg(feature = "untested")]
+pub(crate) const CB_OBJ_MAX: usize = CB_BUF_MAX - 9;
+pub(crate) const CB_OBJ_TAG_MIN: usize = 2; // 1 byte tag + 1 byte len
+#[cfg(feature = "untested")]
+pub(crate) const CB_OBJ_TAG_MAX: usize = (CB_OBJ_TAG_MIN + 2); // 1 byte tag + 3 bytes len
+
+pub(crate) const TAG_ADMIN: u8 = 0x80;
+pub(crate) const TAG_ADMIN_FLAGS_1: u8 = 0x81;
+pub(crate) const TAG_ADMIN_SALT: u8 = 0x82;
+pub(crate) const TAG_ADMIN_TIMESTAMP: u8 = 0x83;
+pub(crate) const TAG_PROTECTED: u8 = 0x88;
+pub(crate) const TAG_PROTECTED_FLAGS_1: u8 = 0x81;
+pub(crate) const TAG_PROTECTED_MGM: u8 = 0x89;
+
+/// PIV Applet ID
+pub(crate) const PIV_AID: [u8; 5] = [0xa0, 0x00, 0x00, 0x03, 0x08];
+
+/// MGMT Applet ID.
+/// <https://developers.yubico.com/PIV/Introduction/Admin_access.html>
+#[cfg(feature = "untested")]
+pub(crate) const MGMT_AID: [u8; 8] = [0xa0, 0x00, 0x00, 0x05, 0x27, 0x47, 0x11, 0x17];
+
+/// YubiKey OTP Applet ID. Needed to query serial on YK4.
+pub(crate) const YK_AID: [u8; 8] = [0xa0, 0x00, 0x00, 0x05, 0x27, 0x20, 0x01, 0x01];

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -30,7 +30,13 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::{consts::*, error::Error, serialization::*, transaction::Transaction, Buffer};
+use crate::{
+    error::Error, serialization::*, transaction::Transaction, Buffer, CB_OBJ_TAG_MIN, TAG_ADMIN,
+    TAG_PROTECTED,
+};
+
+#[cfg(feature = "untested")]
+use crate::{CB_OBJ_MAX, CB_OBJ_TAG_MAX};
 
 #[cfg(feature = "untested")]
 use zeroize::Zeroizing;

--- a/src/mgm.rs
+++ b/src/mgm.rs
@@ -37,7 +37,10 @@ use std::convert::{TryFrom, TryInto};
 use zeroize::{Zeroize, Zeroizing};
 
 #[cfg(feature = "untested")]
-use crate::{consts::*, metadata, yubikey::YubiKey};
+use crate::{
+    metadata, yubikey::YubiKey, CB_BUF_MAX, CB_OBJ_MAX, TAG_ADMIN, TAG_ADMIN_FLAGS_1,
+    TAG_ADMIN_SALT, TAG_PROTECTED, TAG_PROTECTED_MGM,
+};
 #[cfg(feature = "untested")]
 use des::{
     block_cipher_trait::{generic_array::GenericArray, BlockCipher},
@@ -49,6 +52,8 @@ use hmac::Hmac;
 use pbkdf2::pbkdf2;
 #[cfg(feature = "untested")]
 use sha1::Sha1;
+
+pub(crate) const ADMIN_FLAGS_1_PROTECTED_MGM: u8 = 0x02;
 
 #[cfg(feature = "untested")]
 const CB_ADMIN_SALT: usize = 16;

--- a/src/msroots.rs
+++ b/src/msroots.rs
@@ -37,7 +37,8 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::{consts::*, error::Error, serialization::*, yubikey::YubiKey};
+use crate::{error::Error, serialization::*, yubikey::YubiKey};
+use crate::{CB_OBJ_MAX, CB_OBJ_TAG_MAX, CB_OBJ_TAG_MIN};
 use log::error;
 
 const OBJ_MSROOTS1: u32 = 0x005f_ff11;
@@ -48,6 +49,9 @@ const OBJ_MSROOTS3: u32 = 0x005f_ff13;
 #[allow(dead_code)]
 const OBJ_MSROOTS4: u32 = 0x005f_ff14;
 const OBJ_MSROOTS5: u32 = 0x005f_ff15;
+
+const TAG_MSROOTS_END: u8 = 0x82;
+const TAG_MSROOTS_MID: u8 = 0x83;
 
 /// `msroots` file: PKCS#7-formatted certificate store for enterprise trust roots
 pub struct MsRoots(Vec<u8>);

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -3,11 +3,10 @@
 use crate::{
     apdu::Response,
     apdu::{Ins, StatusWords, APDU},
-    consts::*,
     error::Error,
     serialization::*,
     yubikey::*,
-    Buffer, ObjectId,
+    Buffer, ObjectId, CB_BUF_MAX, PIV_AID, YK_AID,
 };
 use log::{error, trace};
 use std::convert::TryInto;
@@ -17,6 +16,7 @@ use zeroize::Zeroizing;
 use crate::{
     key::{AlgorithmId, SlotId},
     mgm::{MgmKey, DES_LEN_3DES},
+    CB_OBJ_MAX,
 };
 
 const CB_PIN_MAX: usize = 8;


### PR DESCRIPTION
Either moves constants into their relevant modules, or puts the remaining ones into `lib.rs`