### PR TITLE
cli: rename 'list' command to 'readers'; improve usage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ application providing general-purpose public-key signing and encryption
 with hardware-backed private keys for RSA (2048/1024) and ECC (P-256/P-384)
 algorithms (e.g, PKCS#1v1.5, ECDSA)
 """
-authors    = ["Tony Arcieri <bascule@gmail.com>", "Yubico AB"]
+authors    = ["Tony Arcieri <tony@iqlusion.io>", "Yubico AB"]
 edition    = "2018"
 license    = "BSD-2-Clause"
 repository = "https://github.com/iqlusioninc/yubikey-piv.rs"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -2,10 +2,9 @@
 name = "yubikey-cli"
 version = "0.0.1"
 description = """
-Command-line interface for performing encryption and signing using RSA and/or
-ECC keys stored on YubiKey devices.
+Command-line interface for performing encryption and signing using RSA/ECC keys stored on YubiKey devices.
 """
-authors = ["Tony Arcieri <bascule@gmail.com>"]
+authors = ["Tony Arcieri <tony@iqlusion.io>"]
 edition = "2018"
 license = "BSD-2-Clause"
 repository = "https://github.com/iqlusioninc/yubikey-piv.rs"

--- a/cli/src/commands/readers.rs
+++ b/cli/src/commands/readers.rs
@@ -4,12 +4,12 @@ use gumdrop::Options;
 use std::process::exit;
 use yubikey_piv::readers::Readers;
 
-/// The `list` subcommand
+/// The `readers` subcommand
 #[derive(Debug, Options)]
-pub struct ListCmd {}
+pub struct ReadersCmd {}
 
-impl ListCmd {
-    /// Run the `list` subcommand
+impl ReadersCmd {
+    /// Run the `readers` subcommand
     pub fn run(&self) {
         let mut readers = Readers::open().unwrap_or_else(|e| {
             status_err!("couldn't open PC/SC context: {}", e);


### PR DESCRIPTION
There are going to be several `list` commands (e.g. `yubikey keys list`) so this is a confusing name.

If we need more than one `readers` subcommand we can change this to be `readers list` eventually.

Separately (in what probably should've been its own commit, mea culpa) this adds slightly better usage.