### PR TITLE
cli: add `status` command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -711,6 +711,14 @@ version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "subtle-encoding"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "syn"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -856,6 +864,7 @@ dependencies = [
  "secrecy 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha-1 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "subtle 2.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "subtle-encoding 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "x509-parser 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -972,6 +981,7 @@ dependencies = [
 "checksum static_assertions 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "7f3eb36b47e512f8f1c9e3d10c2c1965bc992bd9cdb024fa581e2194501c83d3"
 "checksum subtle 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
 "checksum subtle 2.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7c65d530b10ccaeac294f349038a597e435b18fb456aadd0840a623f83b9e941"
+"checksum subtle-encoding 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cbc5188a16f729680b6d495b0deaa776944b8e509d24b7f989489b0d8bbcb63b"
 "checksum syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)" = "dff0acdb207ae2fe6d5976617f887eb1e35a2ba52c13c7234c790960cdad9238"
 "checksum synstructure 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "67656ea1dc1b41b1451851562ea232ec2e5a80242139f7e679ceccfb5d61f545"
 "checksum termcolor 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "96d6098003bde162e4277c70665bd87c326f5a0c3f3fbfb285787fa482d54e6e"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ rsa = "0.1.4"
 secrecy = "0.5"
 sha-1 = "0.8"
 subtle = "2"
+subtle-encoding = "0.5"
 x509-parser = "0.6"
 zeroize = "1"
 

--- a/cli/src/bin/yubikey/main.rs
+++ b/cli/src/bin/yubikey/main.rs
@@ -9,8 +9,8 @@
 )]
 
 use gumdrop::Options;
-use yubikey_cli::commands::YubikeyCli;
+use yubikey_cli::commands::YubiKeyCli;
 
 fn main() {
-    YubikeyCli::parse_args_default_or_exit().run();
+    YubiKeyCli::parse_args_default_or_exit().run();
 }

--- a/cli/src/commands/readers.rs
+++ b/cli/src/commands/readers.rs
@@ -1,8 +1,13 @@
 //! List detected readers
 
+use crate::terminal::STDOUT;
 use gumdrop::Options;
-use std::process::exit;
-use yubikey_piv::readers::Readers;
+use std::{
+    io::{self, Write},
+    process::exit,
+};
+use termcolor::{ColorSpec, StandardStreamLock, WriteColor};
+use yubikey_piv::{Readers, Serial};
 
 /// The `readers` subcommand
 #[derive(Debug, Options)]
@@ -26,6 +31,9 @@ impl ReadersCmd {
             exit(1);
         }
 
+        let mut s = STDOUT.lock();
+        s.reset().unwrap();
+
         for (i, reader) in readers_iter.enumerate() {
             let name = reader.name();
             let mut yubikey = match reader.open() {
@@ -34,7 +42,23 @@ impl ReadersCmd {
             };
 
             let serial = yubikey.serial();
-            println!("{}: {} (serial: {})", i + 1, name, serial);
+            self.print_reader(&mut s, i + 1, &name, serial).unwrap();
         }
+    }
+
+    /// Print a reader
+    fn print_reader(
+        &self,
+        stream: &mut StandardStreamLock<'_>,
+        index: usize,
+        name: &str,
+        serial: Serial,
+    ) -> Result<(), io::Error> {
+        stream.set_color(ColorSpec::new().set_bold(true))?;
+        write!(stream, "{:>3}:", index)?;
+        stream.reset()?;
+        writeln!(stream, " {} (serial: {})", name, serial)?;
+        stream.flush()?;
+        Ok(())
     }
 }

--- a/cli/src/commands/status.rs
+++ b/cli/src/commands/status.rs
@@ -1,0 +1,55 @@
+//! Print device status
+
+use crate::terminal::STDOUT;
+use gumdrop::Options;
+use std::io::{self, Write};
+use termcolor::{ColorSpec, StandardStreamLock, WriteColor};
+use yubikey_piv::YubiKey;
+
+// String to use for `None`
+const NONE_STR: &str = "<none>";
+
+/// The `status` subcommand
+#[derive(Debug, Options)]
+pub struct StatusCmd {}
+
+impl StatusCmd {
+    /// Run the `status` subcommand
+    pub fn run(&self, mut yk: YubiKey) {
+        let mut s = STDOUT.lock();
+        s.reset().unwrap();
+
+        self.attr(&mut s, "version", yk.version()).unwrap();
+        self.attr(&mut s, "serial", yk.serial()).unwrap();
+
+        if let Ok(chuid) = yk.chuid() {
+            self.attr(&mut s, "CHUID", chuid).unwrap();
+        } else {
+            self.attr(&mut s, "CHUID", NONE_STR).unwrap();
+        }
+
+        if let Ok(chuid) = yk.cccid() {
+            self.attr(&mut s, "CCC", chuid).unwrap();
+        } else {
+            self.attr(&mut s, "CCC", NONE_STR).unwrap();
+        }
+
+        self.attr(&mut s, "PIN retries", yk.get_pin_retries().unwrap())
+            .unwrap();
+    }
+
+    /// Print a status attribute
+    fn attr(
+        &self,
+        stream: &mut StandardStreamLock<'_>,
+        name: &str,
+        value: impl ToString,
+    ) -> Result<(), io::Error> {
+        stream.set_color(ColorSpec::new().set_bold(true))?;
+        write!(stream, "{:>12}:", name)?;
+        stream.reset()?;
+        writeln!(stream, " {}", value.to_string())?;
+        stream.flush()?;
+        Ok(())
+    }
+}

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -9,6 +9,6 @@
 )]
 
 #[macro_use]
-pub mod status;
+pub mod terminal;
 
 pub mod commands;

--- a/cli/src/terminal.rs
+++ b/cli/src/terminal.rs
@@ -9,7 +9,7 @@ use termcolor::{Color, ColorChoice, ColorSpec, StandardStream, WriteColor};
 #[macro_export]
 macro_rules! status_ok {
     ($status:expr, $msg:expr) => {
-        $crate::status::Status::new()
+        $crate::terminal::Status::new()
             .justified()
             .bold()
             .color(termcolor::Color::Green)
@@ -25,7 +25,7 @@ macro_rules! status_ok {
 #[macro_export]
 macro_rules! status_warn {
     ($msg:expr) => {
-        $crate::status::Status::new()
+        $crate::terminal::Status::new()
             .bold()
             .color(termcolor::Color::Yellow)
             .status("warning:")
@@ -40,7 +40,7 @@ macro_rules! status_warn {
 #[macro_export]
 macro_rules! status_err {
     ($msg:expr) => {
-        $crate::status::Status::new()
+        $crate::terminal::Status::new()
             .bold()
             .color(termcolor::Color::Red)
             .status("error:")

--- a/src/cccid.rs
+++ b/src/cccid.rs
@@ -32,7 +32,8 @@
 
 use crate::{error::Error, yubikey::YubiKey};
 use getrandom::getrandom;
-use std::fmt::{self, Debug};
+use std::fmt::{self, Debug, Display};
+use subtle_encoding::hex;
 
 /// CCCID size
 pub const CCCID_SIZE: usize = 14;
@@ -114,5 +115,15 @@ impl CCC {
 impl Debug for CCC {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "CCC({:?})", &self.0[..])
+    }
+}
+
+impl Display for CCC {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}",
+            String::from_utf8(hex::encode(&self.0[..])).unwrap()
+        )
     }
 }

--- a/src/chuid.rs
+++ b/src/chuid.rs
@@ -32,7 +32,8 @@
 
 use crate::{error::Error, yubikey::YubiKey};
 use getrandom::getrandom;
-use std::fmt::{self, Debug};
+use std::fmt::{self, Debug, Display};
+use subtle_encoding::hex;
 
 /// CHUID size
 pub const CHUID_SIZE: usize = 59;
@@ -146,6 +147,16 @@ impl CHUID {
 
         let txn = yubikey.begin_transaction()?;
         txn.save_object(OBJ_CHUID, &buf)
+    }
+}
+
+impl Display for CHUID {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}",
+            String::from_utf8(hex::encode(&self.0[..])).unwrap()
+        )
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,7 +156,13 @@ pub mod settings;
 mod transaction;
 pub mod yubikey;
 
-pub use self::{error::Error, key::Key, mgm::MgmKey, readers::Readers, yubikey::YubiKey};
+pub use self::{
+    error::Error,
+    key::Key,
+    mgm::MgmKey,
+    readers::Readers,
+    yubikey::{Serial, YubiKey},
+};
 
 /// Object identifiers
 pub type ObjectId = u32;

--- a/src/yubikey.rs
+++ b/src/yubikey.rs
@@ -43,6 +43,7 @@ use pcsc::Card;
 use std::{
     convert::TryFrom,
     fmt::{self, Display},
+    str::FromStr,
 };
 
 #[cfg(feature = "untested")]
@@ -100,6 +101,14 @@ impl From<u32> for Serial {
 impl From<Serial> for u32 {
     fn from(serial: Serial) -> u32 {
         serial.0
+    }
+}
+
+impl FromStr for Serial {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Error> {
+        u32::from_str(s).map(Serial).map_err(|_| Error::ParseError)
     }
 }
 
@@ -350,7 +359,6 @@ impl YubiKey {
     }
 
     /// Get the number of PIN retries
-    #[cfg(feature = "untested")]
     pub fn get_pin_retries(&mut self) -> Result<u8, Error> {
         let txn = self.begin_transaction()?;
 


### PR DESCRIPTION
Provides equivalent functionality to `yubico-piv-tool`

This PR also contains a basic framework for initializing a YubiKey, including a standard set of argument prefixes (i.e. `-s` or `--serial`) for selecting a specific key by its serial number.