### PR TITLE
tests: eliminate usage of `rand` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -992,7 +992,6 @@ dependencies = [
  "num-bigint 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "pbkdf2 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pcsc 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "ring 0.16.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "rsa 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "secrecy 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,6 @@ zeroize = "1"
 
 [dev-dependencies]
 env_logger = "0.7"
-rand = "0.5"
 ring = "0.16.9"
 lazy_static = "1"
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -3,10 +3,9 @@
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, trivial_casts, unused_qualifications)]
 
+use getrandom::getrandom;
 use lazy_static::lazy_static;
 use log::trace;
-use num_bigint::RandBigInt;
-use rand::rngs::OsRng;
 use rsa::{hash::Hashes::SHA2_256, PaddingScheme, PublicKey};
 use sha2::{Digest, Sha256};
 use std::convert::TryInto;
@@ -129,13 +128,14 @@ fn generate_self_signed_cert(algorithm: AlgorithmId) -> Certificate {
     )
     .unwrap();
 
-    let mut rng = OsRng::new().unwrap();
+    let mut serial = [0u8; 20];
+    getrandom(&mut serial).unwrap();
 
     // Generate a self-signed certificate for the new key.
     let cert_result = Certificate::generate_self_signed(
         &mut yubikey,
         slot,
-        rng.gen_biguint(20 * 8),
+        serial,
         None,
         "testSubject".to_owned(),
         generated,


### PR DESCRIPTION
Otherwise dependabot will nag us until `num-bigint` updates.