### PR TITLE
.github: split security_audit.yml; ignore spin advisory

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -150,26 +150,3 @@ jobs:
         with:
           command: clippy
           args: --all --all-features -- -D warnings
-
-  # TODO: use actions-rs/audit-check
-  security_audit:
-    name: Security Audit
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v1
-
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-
-      - name: Install cargo audit
-        run: cargo install cargo-audit
-
-      - name: Run cargo audit
-        uses: actions-rs/cargo@v1
-        with:
-          command: audit
-          args: --deny-warnings

--- a/.github/workflows/security_audit.yml
+++ b/.github/workflows/security_audit.yml
@@ -1,0 +1,45 @@
+name: Security Audit
+on:
+  pull_request:
+    paths: Cargo.lock
+  push:
+    branches: develop
+    paths: Cargo.lock
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  # TODO: use actions-rs/audit-check
+  security_audit:
+    name: Security Audit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v1
+
+      - name: Cache cargo registry
+        uses: actions/cache@v1
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('Cargo.lock') }}
+
+      - name: Cache cargo index
+        uses: actions/cache@v1
+        with:
+          path: ~/.cargo/git
+          key: ${{ runner.os }}-cargo-index-${{ hashFiles('Cargo.lock') }}
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+
+      - name: Install cargo audit
+        run: cargo install cargo-audit
+
+      - name: Run cargo audit
+        uses: actions-rs/cargo@v1
+        with:
+          command: audit
+          args: --deny-warnings --ignore RUSTSEC-2019-0031 # spin


### PR DESCRIPTION
Splits the security audit into a separate file which only runs on Cargo.toml changes or on a regular schedule.

Ignores the [RUSTSEC-2019-0031](https://rustsec.org/advisories/RUSTSEC-2019-0031.html) unmaintained warning advisory about `spin`.