### PR TITLE
yubikey-piv v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,49 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.0.3] (2019-12-02)
+## 0.1.0 (2020-10-18)
+### Added
+- `Certificate::generate_self_signed` ([#80])
+- `YubiKey::open_by_serial` ([#69])
+- CCCID/CHUID tests and cleanups ([#65])
+- Test `Config::get` ([#64])
+- Test `Key::list` ([#61])
+- Test `YubiKey::verify_pin` ([#60])
+
+### Changed
+- Bump `crypto-mac`, `des`, `hmac`, `pbkdf2` ([#177])
+- Bump `p256` to v0.5; `p384` to v0.4; MSRV 1.44+ ([#175])
+- Refactor key import function ([#128])
+- Extract `ChangeRefAction` enum ([#82])
+- TLV extraction ([#73])
+- Rename `container` to `mscmap` ([#68])
+- Finish eliminating `consts` module ([#67])
+- Move `sign`/`decrypt`/`import`/`attest` to the `key` module ([#62])
+
+### Fixed
+- `pcsc::Error::NoReadersAvailable` -> `Error::NotFound` in `YubiKey::open*` ([#88])
+
+### Removed
+- YubiKey NEO support ([#63])
+
+[#177]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/177
+[#175]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/175
+[#128]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/128
+[#82]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/82
+[#73]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/73
+[#88]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/88
+[#80]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/80
+[#69]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/69
+[#68]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/68
+[#67]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/67
+[#65]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/65
+[#64]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/64
+[#63]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/63
+[#62]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/62
+[#61]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/61
+[#60]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/60
+
+## 0.0.3 (2019-12-02)
 ### Added
 - Initial `Readers` enumerator for detecting YubiKeys ([#51])
 - Certificate parsing ([#45])
@@ -20,7 +62,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Ins` (APDU instruction codes) enum ([#33])
 - Factor `Response` into `apdu` module; improved debugging ([#32])
 
-[0.0.3]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/53
 [#51]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/51
 [#45]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/45
 [#44]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/44
@@ -33,7 +74,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#33]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/33
 [#32]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/32
 
-## [0.0.2] (2019-11-25)
+## 0.0.2 (2019-11-25)
 ### Added
 - `untested` Cargo feature to mark untested functionality ([#30])
 - Initial connect test and docs ([#19])
@@ -48,7 +89,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Use `log` crate for logging ([#7])
 - Replace `ErrorKind::Ok` with `Result` ([#6])
 
-[0.0.2]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/31
 [#30]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/30
 [#19]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/19
 [#17]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/17
@@ -61,4 +101,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#6]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/6
 
 ## 0.0.1 (2019-11-18)
-- It typechecks, ship it!
+- Initial release

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1143,7 +1143,7 @@ dependencies = [
 
 [[package]]
 name = "yubikey-piv"
-version = "0.0.3"
+version = "0.1.0"
 dependencies = [
  "chrono",
  "cookie-factory",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "yubikey-piv"
-version = "0.0.3" # Also update html_root_url in lib.rs when bumping this
+version = "0.1.0" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust host-side driver for the YubiKey Personal Identity Verification (PIV)
 application providing general-purpose public-key signing and encryption

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -2,11 +2,12 @@
 name = "yubikey-cli"
 version = "0.0.1"
 description = """
-Command-line interface for performing encryption and signing using RSA/ECC keys stored on YubiKey devices.
+Command-line interface for performing encryption and signing using RSA/ECC keys
+stored on YubiKey devices.
 """
-authors = ["Tony Arcieri <tony@iqlusion.io>"]
-edition = "2018"
-license = "BSD-2-Clause"
+authors    = ["Tony Arcieri <tony@iqlusion.io>"]
+edition    = "2018"
+license    = "BSD-2-Clause"
 repository = "https://github.com/iqlusioninc/yubikey-piv.rs"
 readme     = "README.md"
 categories = ["command-line-utilities", "cryptography", "hardware-support"]
@@ -21,4 +22,4 @@ sha2 = "0.8"
 subtle-encoding = "0.5"
 termcolor = "1"
 x509-parser = "0.7"
-yubikey-piv = { version = "0.0.3", path = ".." }
+yubikey-piv = { version = "0.1", path = ".." }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@
 //!
 //! ## Minimum Supported Rust Version
 //!
-//! Rust 1.39+
+//! Rust 1.44+
 //!
 //! ## Supported YubiKeys
 //!
@@ -123,7 +123,7 @@
 
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/iqlusioninc/yubikey-piv.rs/develop/img/logo.png",
-    html_root_url = "https://docs.rs/yubikey-piv/0.0.3"
+    html_root_url = "https://docs.rs/yubikey-piv/0.1.0"
 )]
 #![forbid(unsafe_code)]
 #![warn(


### PR DESCRIPTION
### Added
- `Certificate::generate_self_signed` ([#80])
- `YubiKey::open_by_serial` ([#69])
- CCCID/CHUID tests and cleanups ([#65])
- Test `Config::get` ([#64])
- Test `Key::list` ([#61])
- Test `YubiKey::verify_pin` ([#60])

### Changed
- Bump `crypto-mac`, `des`, `hmac`, `pbkdf2` ([#177])
- Bump `p256` to v0.5; `p384` to v0.4; MSRV 1.44+ ([#175])
- Refactor key import function ([#128])
- Extract `ChangeRefAction` enum ([#82])
- TLV extraction ([#73])
- Rename `container` to `mscmap` ([#68])
- Finish eliminating `consts` module ([#67])
- Move `sign`/`decrypt`/`import`/`attest` to the `key` module ([#62])

### Fixed
- `pcsc::Error::NoReadersAvailable` -> `Error::NotFound` in `YubiKey::open*` ([#88])

### Removed
- YubiKey NEO support ([#63])

[#177]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/177
[#175]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/175
[#128]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/128
[#82]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/82
[#73]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/73
[#88]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/88
[#80]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/80
[#69]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/69
[#68]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/68
[#67]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/67
[#65]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/65
[#64]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/64
[#63]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/63
[#62]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/62
[#61]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/61
[#60]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/60