### PR TITLE
yubikey-cli v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.1.0 (2020-10-18)
+## 0.1.0 (2020-10-19)
 ### Added
 - `Certificate::generate_self_signed` ([#80])
 - `YubiKey::open_by_serial` ([#69])

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1028,7 +1028,7 @@ dependencies = [
 
 [[package]]
 name = "yubikey-cli"
-version = "0.0.1"
+version = "0.1.0"
 dependencies = [
  "env_logger",
  "gumdrop",

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -4,5 +4,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.0 (2020-10-19)
+### Added
+- `status` command ([#72], [#74])
+
+### Changed
+- Bump `yubikey-piv` to v0.1.0 ([#180])
+- Bump `x509-parser` to v0.8 ([#181])
+- Bump `sha2` to v0.9 ([#182])
+- Rename `list` command to `readers`; improve usage ([#71])
+
+[#182]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/182
+[#181]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/181
+[#180]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/180
+[#74]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/74
+[#72]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/72
+[#71]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/71
+
 ## 0.0.1 (2019-12-02)
 - Initial release

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yubikey-cli"
-version = "0.0.1"
+version = "0.1.0"
 description = """
 Command-line interface for performing encryption and signing using RSA/ECC keys
 stored on YubiKey devices.


### PR DESCRIPTION
### Added
- `status` command ([#72], [#74])

### Changed
- Bump `yubikey-piv` to v0.1.0 ([#180])
- Bump `x509-parser` to v0.8 ([#181])
- Bump `sha2` to v0.9 ([#182])
- Rename `list` command to `readers`; improve usage ([#71])

[#182]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/182
[#181]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/181
[#180]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/180
[#74]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/74
[#72]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/72
[#71]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/71