### PR TITLE
Improve self-signed certificates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1047,9 +1047,9 @@ checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
 
 [[package]]
 name = "x509"
-version = "0.1.2"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9335b8ff50b6a0de184b3eeb11fdce74224e3af90ca7265012512e73fc999d1a"
+checksum = "ca3cec94c3999f31341553f358ef55f65fc031291a022cd42ec0ce7219560c76"
 dependencies = [
  "chrono",
  "cookie-factory",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ sha-1 = "0.9"
 sha2 = "0.9"
 subtle = "2"
 subtle-encoding = "0.5"
-x509 = "0.1.2"
+x509 = "0.2"
 x509-parser = "0.9"
 zeroize = "1"
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -10,6 +10,7 @@ use rsa::{hash::Hash::SHA2_256, PaddingScheme, PublicKey};
 use sha2::{Digest, Sha256};
 use std::convert::TryInto;
 use std::{env, sync::Mutex};
+use x509::RelativeDistinguishedName;
 use yubikey_piv::{
     certificate::{Certificate, PublicKeyInfo},
     key::{self, AlgorithmId, Key, RetiredSlotId, SlotId},
@@ -132,13 +133,15 @@ fn generate_self_signed_cert(algorithm: AlgorithmId) -> Certificate {
     getrandom(&mut serial).unwrap();
 
     // Generate a self-signed certificate for the new key.
+    let extensions: &[x509::Extension<'_, &[u64]>] = &[];
     let cert_result = Certificate::generate_self_signed(
         &mut yubikey,
         slot,
         serial,
         None,
-        "testSubject".to_owned(),
+        &[RelativeDistinguishedName::common_name("testSubject")],
         generated,
+        extensions,
     );
 
     assert!(cert_result.is_ok());


### PR DESCRIPTION
Adds support for:
- A hierarchical SubjectName field.
- Certificate extensions.

This uses str4d/x509.rs#3 and str4d/x509.rs#4.