### PR TITLE
yubikey-cli v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1091,7 +1091,7 @@ dependencies = [
 
 [[package]]
 name = "yubikey-cli"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "env_logger",
  "gumdrop",

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.0 (2021-01-30)
+### Changed
+- Bump MSRV to 1.46+ ([#208])
+- Bump `yubikey-piv` dependency to v0.2.0 ([#220])
+
+[#208]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/208
+[#220]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/220
+
 ## 0.1.0 (2020-10-19)
 ### Added
 - `status` command ([#72], [#74])

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yubikey-cli"
-version = "0.1.0"
+version = "0.2.0"
 description = """
 Command-line interface for performing encryption and signing using RSA/ECC keys
 stored on YubiKey devices.


### PR DESCRIPTION
### Changed
- Bump MSRV to 1.46+ ([#208])
- Bump `yubikey-piv` dependency to v0.2.0 ([#220])

[#208]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/208
[#220]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/220