### PR TITLE
Create typed structs for PIN-protected and admin metadata

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -178,11 +178,9 @@ pub(crate) const CB_OBJ_TAG_MIN: usize = 2; // 1 byte tag + 1 byte len
 #[cfg(feature = "untested")]
 pub(crate) const CB_OBJ_TAG_MAX: usize = CB_OBJ_TAG_MIN + 2; // 1 byte tag + 3 bytes len
 
-pub(crate) const TAG_ADMIN: u8 = 0x80;
 pub(crate) const TAG_ADMIN_FLAGS_1: u8 = 0x81;
 pub(crate) const TAG_ADMIN_SALT: u8 = 0x82;
 pub(crate) const TAG_ADMIN_TIMESTAMP: u8 = 0x83;
-pub(crate) const TAG_PROTECTED: u8 = 0x88;
 pub(crate) const TAG_PROTECTED_FLAGS_1: u8 = 0x81;
 pub(crate) const TAG_PROTECTED_MGM: u8 = 0x89;
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -108,6 +108,35 @@ fn test_verify_pin() {
 }
 
 //
+// Management key support
+//
+
+#[cfg(feature = "untested")]
+#[test]
+#[ignore]
+fn test_protected_mgmkey() {
+    let mut yubikey = YUBIKEY.lock().unwrap();
+
+    assert!(yubikey.verify_pin(b"123456").is_ok());
+    assert!(yubikey.authenticate(MgmKey::default()).is_ok());
+
+    // Set a protected management key.
+    assert!(MgmKey::generate()
+        .unwrap()
+        .set_protected(&mut yubikey)
+        .is_ok());
+    let protected = MgmKey::get_protected(&mut yubikey).unwrap();
+    assert!(yubikey.authenticate(MgmKey::default()).is_err());
+    assert!(yubikey.authenticate(protected.clone()).is_ok());
+
+    // Set back to the default management key.
+    // TODO: This does not clear the previous key from the protected metadata.
+    assert!(MgmKey::default().set(&mut yubikey, None).is_ok());
+    assert!(yubikey.authenticate(protected).is_err());
+    assert!(yubikey.authenticate(MgmKey::default()).is_ok());
+}
+
+//
 // Certificate support
 //
 


### PR DESCRIPTION
`MgmKey::set_protected` and `YubiKey::set_pin_last_changed` both contained bugs resulting from the conversion of C pointer logic (incorrect buffer management). The new `Metadata` struct holds its own buffer, avoiding the problem.

Part of #27.