### PR TITLE
Replace MgmKey::set with MgmKey::{set_default, set_manual}

### DIFF
--- a/src/mgm.rs
+++ b/src/mgm.rs
@@ -185,9 +185,9 @@ impl MgmKey {
 
     /// Set the management key (MGM)
     #[cfg(feature = "untested")]
-    pub fn set(&self, yubikey: &mut YubiKey, touch: Option<u8>) -> Result<(), Error> {
+    pub fn set(&self, yubikey: &mut YubiKey, require_touch: bool) -> Result<(), Error> {
         let txn = yubikey.begin_transaction()?;
-        txn.set_mgm_key(&self, touch)
+        txn.set_mgm_key(&self, require_touch)
     }
 
     /// Resets the management key for the given YubiKey to the default value.
@@ -197,7 +197,7 @@ impl MgmKey {
     pub fn set_default(yubikey: &mut YubiKey) -> Result<(), Error> {
         let txn = yubikey.begin_transaction()?;
 
-        txn.set_mgm_key(&MgmKey::default(), None).map_err(|e| {
+        txn.set_mgm_key(&MgmKey::default(), false).map_err(|e| {
             // Log a warning, since the device mgm key is corrupt or we're in a state
             // where we can't set the mgm key.
             error!("could not set new derived mgm key, err = {}", e);
@@ -254,7 +254,7 @@ impl MgmKey {
     pub fn set_protected(&self, yubikey: &mut YubiKey) -> Result<(), Error> {
         let txn = yubikey.begin_transaction()?;
 
-        txn.set_mgm_key(self, None).map_err(|e| {
+        txn.set_mgm_key(self, false).map_err(|e| {
             // log a warning, since the device mgm key is corrupt or we're in
             // a state where we can't set the mgm key
             error!("could not set new derived mgm key, err = {}", e);

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -229,14 +229,8 @@ impl<'tx> Transaction<'tx> {
 
     /// Set the management key (MGM).
     #[cfg(feature = "untested")]
-    pub fn set_mgm_key(&self, new_key: &MgmKey, touch: Option<u8>) -> Result<(), Error> {
-        let p2 = match touch.unwrap_or_default() {
-            0 => 0xff,
-            1 => 0xfe,
-            _ => {
-                return Err(Error::GenericError);
-            }
-        };
+    pub fn set_mgm_key(&self, new_key: &MgmKey, require_touch: bool) -> Result<(), Error> {
+        let p2 = if require_touch { 0xfe } else { 0xff };
 
         let mut data = [0u8; DES_LEN_3DES + 3];
         data[0] = ALGO_3DES;

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -114,7 +114,7 @@ fn test_verify_pin() {
 #[cfg(feature = "untested")]
 #[test]
 #[ignore]
-fn test_protected_mgmkey() {
+fn test_set_mgmkey() {
     let mut yubikey = YUBIKEY.lock().unwrap();
 
     assert!(yubikey.verify_pin(b"123456").is_ok());
@@ -130,10 +130,19 @@ fn test_protected_mgmkey() {
     assert!(yubikey.authenticate(MgmKey::default()).is_err());
     assert!(yubikey.authenticate(protected.clone()).is_ok());
 
+    // Set a manual management key.
+    let manual = MgmKey::generate().unwrap();
+    assert!(manual.set_manual(&mut yubikey, false).is_ok());
+    assert!(MgmKey::get_protected(&mut yubikey).is_err());
+    assert!(yubikey.authenticate(MgmKey::default()).is_err());
+    assert!(yubikey.authenticate(protected.clone()).is_err());
+    assert!(yubikey.authenticate(manual.clone()).is_ok());
+
     // Set back to the default management key.
     assert!(MgmKey::set_default(&mut yubikey).is_ok());
     assert!(MgmKey::get_protected(&mut yubikey).is_err());
     assert!(yubikey.authenticate(protected).is_err());
+    assert!(yubikey.authenticate(manual).is_err());
     assert!(yubikey.authenticate(MgmKey::default()).is_ok());
 }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -118,6 +118,7 @@ fn test_protected_mgmkey() {
     let mut yubikey = YUBIKEY.lock().unwrap();
 
     assert!(yubikey.verify_pin(b"123456").is_ok());
+    assert!(MgmKey::get_protected(&mut yubikey).is_err());
     assert!(yubikey.authenticate(MgmKey::default()).is_ok());
 
     // Set a protected management key.
@@ -130,8 +131,8 @@ fn test_protected_mgmkey() {
     assert!(yubikey.authenticate(protected.clone()).is_ok());
 
     // Set back to the default management key.
-    // TODO: This does not clear the previous key from the protected metadata.
-    assert!(MgmKey::default().set(&mut yubikey, None).is_ok());
+    assert!(MgmKey::set_default(&mut yubikey).is_ok());
+    assert!(MgmKey::get_protected(&mut yubikey).is_err());
     assert!(yubikey.authenticate(protected).is_err());
     assert!(yubikey.authenticate(MgmKey::default()).is_ok());
 }


### PR DESCRIPTION
The new methods wipe any metadata related to derived and PIN-protected management keys.

Part of #27.