### PR TITLE
yubikey-piv v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.3.0 (2021-03-22)
+### Added
+- Typed structs for PIN-protected and admin metadata ([#223])
+- `MgmKey::set_default`/`MgmKey::set_manual` methods ([#224])
+
+### Changed
+- Have `Transaction::set_mgm_key` take touch requirement as bool ([#224])
+
+### Removed
+- `MgmKey::set` method ([#224])
+
+[#223]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/223
+[#224]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/224
+
 ## 0.2.0 (2021-01-30)
 ### Changed
 - Bump `der-parser` to v5.0 ([#194])

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1094,7 +1094,7 @@ dependencies = [
 
 [[package]]
 name = "yubikey-piv"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "chrono",
  "cookie-factory",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "yubikey-piv"
-version = "0.2.0" # Also update html_root_url in lib.rs when bumping this
+version = "0.3.0" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust host-side driver for the YubiKey Personal Identity Verification (PIV)
 application providing general-purpose public-key signing and encryption

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -22,4 +22,4 @@ sha2 = "0.9"
 subtle-encoding = "0.5"
 termcolor = "1"
 x509-parser = "0.9"
-yubikey-piv = { version = "0.2", path = ".." }
+yubikey-piv = { version = "0.3", path = ".." }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,7 +123,7 @@
 
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/iqlusioninc/yubikey-piv.rs/main/img/logo.png",
-    html_root_url = "https://docs.rs/yubikey-piv/0.1.0"
+    html_root_url = "https://docs.rs/yubikey-piv/0.3.0"
 )]
 #![forbid(unsafe_code)]
 #![warn(


### PR DESCRIPTION
### Added
- Typed structs for PIN-protected and admin metadata ([#223])
- `MgmKey::set_default`/`MgmKey::set_manual` methods ([#224])

### Changed
- Have `Transaction::set_mgm_key` take touch requirement as bool ([#224])

### Removed
- `MgmKey::set` method ([#224])

[#223]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/223
[#224]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/224