### PR TITLE
mgm: remove `untested` gating from tested methods

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = [".", "cli"]
 
 [workspace.dependencies]
 sha2 = "0.11.0-rc.0"
-x509-cert = { version = "0.3.0-rc.1", features = [ "builder", "hazmat" ] }
+x509-cert = { version = "0.3.0-rc.1", features = ["builder", "hazmat"] }
 
 [dependencies]
 bitflags = "2.5.0"
@@ -54,6 +54,10 @@ once_cell = "1"
 
 [features]
 untested = []
+
+[[example]]
+name = "change-mode"
+required-features = ["untested"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -1,5 +1,6 @@
-#![allow(dead_code)]
 //! Miscellaneous constant values
+
+#![allow(dead_code)]
 
 /// YubiKey max buffer size
 pub(crate) const CB_BUF_MAX: usize = 3072;
@@ -8,7 +9,6 @@ pub(crate) const CB_BUF_MAX: usize = 3072;
 pub(crate) const CB_OBJ_MAX: usize = CB_BUF_MAX - 9;
 
 pub(crate) const CB_OBJ_TAG_MIN: usize = 2; // 1 byte tag + 1 byte len
-#[cfg(feature = "untested")]
 pub(crate) const CB_OBJ_TAG_MAX: usize = CB_OBJ_TAG_MIN + 2; // 1 byte tag + 3 bytes len
 
 // Admin tags

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -30,16 +30,15 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::marker::PhantomData;
+use std::{iter, marker::PhantomData};
 use zeroize::Zeroizing;
 
-use crate::{serialization::*, transaction::Transaction, Buffer, Error, Result};
-
-#[cfg(feature = "untested")]
-use crate::consts::{CB_OBJ_MAX, CB_OBJ_TAG_MAX};
-
-#[cfg(feature = "untested")]
-use std::iter;
+use crate::{
+    consts::{CB_OBJ_MAX, CB_OBJ_TAG_MAX},
+    serialization::*,
+    transaction::Transaction,
+    Buffer, Error, Result,
+};
 
 const TAG_ADMIN: u8 = 0x80;
 const TAG_PROTECTED: u8 = 0x88;
@@ -87,7 +86,6 @@ impl<T: MetadataType> Metadata<T> {
     }
 
     /// Write metadata
-    #[cfg(feature = "untested")]
     pub(crate) fn write(&self, txn: &Transaction<'_>) -> Result<()> {
         if self.inner.len() > CB_OBJ_MAX - CB_OBJ_TAG_MAX {
             return Err(Error::GenericError);
@@ -104,7 +102,6 @@ impl<T: MetadataType> Metadata<T> {
     }
 
     /// Delete metadata
-    #[cfg(feature = "untested")]
     pub(crate) fn delete(txn: &Transaction<'_>) -> Result<()> {
         txn.save_object(T::obj_id(), &[])
     }
@@ -127,7 +124,6 @@ impl<T: MetadataType> Metadata<T> {
     }
 
     /// Set metadata item
-    #[cfg(feature = "untested")]
     pub(crate) fn set_item(&mut self, tag: u8, item: &[u8]) -> Result<()> {
         let mut cb_temp: usize = 0;
         let mut tag_temp: u8 = 0;
@@ -216,7 +212,6 @@ impl<T: MetadataType> Metadata<T> {
 }
 
 /// Get the size of a length tag for the given length
-#[cfg(feature = "untested")]
 fn get_length_size(length: usize) -> usize {
     if length < 0x80 {
         1

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -5,6 +5,7 @@ use crate::{
     apdu::{Apdu, Ins, StatusWords},
     consts::{CB_BUF_MAX, CB_OBJ_MAX},
     error::{Error, Result},
+    mgm::{MgmKey, DES_LEN_3DES},
     otp,
     piv::{self, AlgorithmId, SlotId},
     serialization::*,
@@ -15,7 +16,7 @@ use log::{error, trace};
 use zeroize::Zeroizing;
 
 #[cfg(feature = "untested")]
-use crate::mgm::{DeviceConfig, DeviceInfo, Lock, MgmKey, DES_LEN_3DES};
+use crate::mgm::{DeviceConfig, DeviceInfo, Lock};
 
 const CB_PIN_MAX: usize = 8;
 
@@ -247,7 +248,6 @@ impl<'tx> Transaction<'tx> {
     }
 
     /// Set the management key (MGM).
-    #[cfg(feature = "untested")]
     pub fn set_mgm_key(&self, new_key: &MgmKey, require_touch: bool) -> Result<()> {
         let p2 = if require_touch { 0xfe } else { 0xff };
 


### PR DESCRIPTION
Removes the `#[cfg(feature = "untested")]` gating from all methods tested in `tests/integration.rs` and their dependent codepaths.