### PR TITLE
Implement PrehashSigner on yubikey::Signer.

### DIFF
--- a/src/certificate.rs
+++ b/src/certificate.rs
@@ -309,6 +309,10 @@ pub mod yubikey_signer {
 
         /// Prepare buffer before submitting it for signature
         fn prepare(input: &[u8]) -> SigResult<Vec<u8>>;
+
+        /// Prepare a prehashed message before submitting it for signature
+        fn prepare_prehash(hashed: &[u8]) -> SigResult<Vec<u8>>;
+
         /// Read back the signature from the device
         fn read_signature(input: &[u8]) -> SigResult<Self::Signature>;
     }
@@ -322,6 +326,10 @@ pub mod yubikey_signer {
 
         fn prepare(input: &[u8]) -> SigResult<Vec<u8>> {
             Ok(Sha256::digest(input).to_vec())
+        }
+
+        fn prepare_prehash(hashed: &[u8]) -> SigResult<Vec<u8>> {
+            Ok(hashed.to_vec())
         }
 
         fn read_signature(input: &[u8]) -> SigResult<Self::Signature> {
@@ -338,6 +346,10 @@ pub mod yubikey_signer {
 
         fn prepare(input: &[u8]) -> SigResult<Vec<u8>> {
             Ok(Sha384::digest(input).to_vec())
+        }
+
+        fn prepare_prehash(hashed: &[u8]) -> SigResult<Vec<u8>> {
+            Ok(hashed.to_vec())
         }
 
         fn read_signature(input: &[u8]) -> SigResult<Self::Signature> {
@@ -399,7 +411,10 @@ pub mod yubikey_signer {
 
         fn prepare(input: &[u8]) -> SigResult<Vec<u8>> {
             let hashed = Sha256::digest(input).to_vec();
+            Self::prepare_prehash(&hashed)
+        }
 
+        fn prepare_prehash(hashed: &[u8]) -> SigResult<Vec<u8>> {
             OctetString::new(hashed)
                 .map_err(|e| e.into())
                 .and_then(Self::emsa_pkcs1_1_5)
@@ -487,6 +502,22 @@ pub mod yubikey_signer {
     impl<KT: KeyType> signature::Signer<KT::Signature> for Signer<'_, KT> {
         fn try_sign(&self, msg: &[u8]) -> SigResult<KT::Signature> {
             let data = KT::prepare(msg)?;
+
+            let out = sign_data(
+                &mut self.yubikey.borrow_mut(),
+                &data,
+                KT::ALGORITHM,
+                self.key,
+            )
+            .map_err(signature::Error::from_source)?;
+            let out = KT::read_signature(&out)?;
+            Ok(out)
+        }
+    }
+
+    impl<KT: KeyType> signature::hazmat::PrehashSigner<KT::Signature> for Signer<'_, KT> {
+        fn sign_prehash(&self, hashed: &[u8]) -> SigResult<KT::Signature> {
+            let data = KT::prepare_prehash(hashed)?;
 
             let out = sign_data(
                 &mut self.yubikey.borrow_mut(),


### PR DESCRIPTION
Hello,

I'm currently working on integrating signing RPMs through the `rpm` crate using a yubikey with the `yubikey.rs`. Unfortunately, the `pgp` crate (on which `rpm` depends) requires the underlying signer to implement [PrehashSigner](https://docs.rs/pgp/0.17.0/pgp/types/trait.SecretKeyTrait.html#impl-SecretKeyTrait-for-RsaSigner%3CT,+D%3E).

Thankfully, it looks like implementing it in yubikey-rs is rather trivial: from what I could tell, the hashing is done by the library, and not the yubikey itself. So it only requires removing the hashing step from the Signer, which is what this PR does.