### PR TITLE
piv: improve compatibility with ISO 7816-compliant PIV devices

### DIFF
--- a/src/apdu.rs
+++ b/src/apdu.rs
@@ -114,11 +114,31 @@ impl Apdu {
         self
     }
 
-    /// Transmit this APDU using the given card transaction
+    /// Transmit this APDU using the given card transaction.
+    ///
+    /// Handles ISO 7816-4 `SW1=61` (bytes remaining) responses by issuing
+    /// [`Ins::GetResponseApdu`] commands until all response data is collected.
     pub fn transmit(&self, txn: &Transaction<'_>, recv_len: usize) -> Result<Response> {
         trace!(">>> {:?}", self);
-        let response = Response::from(txn.transmit(&self.to_bytes(), recv_len)?);
+        let mut response = Response::from(txn.transmit(&self.to_bytes(), recv_len)?);
         trace!("<<< {:?}", &response);
+
+        if let StatusWords::BytesRemaining { .. } = response.status_words() {
+            let mut data = response.data().to_vec();
+            let mut sw = response.status_words();
+
+            while let StatusWords::BytesRemaining { .. } = sw {
+                let next = Response::from(
+                    txn.transmit(&Apdu::new(Ins::GetResponseApdu).to_bytes(), recv_len)?,
+                );
+                trace!("<<< {:?}", &next);
+                data.extend_from_slice(next.data());
+                sw = next.status_words();
+            }
+
+            response = Response::new(sw, data);
+        }
+
         Ok(response)
     }
 

--- a/src/piv.rs
+++ b/src/piv.rs
@@ -599,7 +599,13 @@ impl Key {
             };
 
             if !buf.is_empty() {
-                let cert = Certificate::from_bytes(buf)?;
+                let cert = match Certificate::from_bytes(buf) {
+                    Ok(c) => c,
+                    Err(e) => {
+                        debug!("error parsing certificate in slot {:?}: {}", slot, e);
+                        continue;
+                    }
+                };
                 keys.push(Key { slot, cert });
             }
         }


### PR DESCRIPTION
This PR fixes two small issues that prevent yubikey.rs from working with non-YubiKey PIV devices (tested with a Token2 PIN+ key via age-plugin-yubikey). Both changes are purely defensive and have no effect on standard YubiKeys. Therefore, I hope it is okay to suggest these minor modifications.

### GET RESPONSE chaining (SW1=61)

Some PIV cards return SW1=61 when the response doesn't fit in one buffer, signaling that more bytes are available. Per NIST SP 800-73-5, section 5.6 Table 7, the host should issue GET RESPONSE (INS=C0) to collect the rest. Without this, `Apdu::transmit()` silently returns incomplete data and parsing fails downstream. Yubico's own yubico-piv-tool does the same thing (`_ykpiv_transfer_data` in lib/ykpiv.c).

### Graceful handling of unparseable certificates in `Key::list()`

If any slot holds a certificate that fails to parse, the current code bails out entirely (i.e., no keys are returned at all). This changes that to a `debug!()` log and continues, so one problematic slot doesn't block access to all the others. This is the exact behaviour that is done just above the changed code when calling `read_certificate`.


Thank you for considering the changes and let me know if you have any questions or comments.