### PR TITLE
Remove some items from the untested feature

### DIFF
--- a/src/cccid.rs
+++ b/src/cccid.rs
@@ -99,7 +99,6 @@ impl CccId {
     }
 
     /// Set Cardholder Capability Container (CCC) ID
-    #[cfg(feature = "untested")]
     pub fn set(&self, yubikey: &mut YubiKey) -> Result<()> {
         let mut buf = CCC_TMPL.to_vec();
         buf[0..self.0.len()].copy_from_slice(&self.0);

--- a/src/chuid.rs
+++ b/src/chuid.rs
@@ -112,7 +112,6 @@ impl ChuId {
     }
 
     /// Set Cardholder Unique Identifier (CHUID)
-    #[cfg(feature = "untested")]
     pub fn set(&self, yubikey: &mut YubiKey) -> Result<()> {
         let mut buf = CHUID_TMPL.to_vec();
         buf[..Self::BYTE_SIZE].copy_from_slice(&self.0);

--- a/src/piv.rs
+++ b/src/piv.rs
@@ -67,13 +67,10 @@ use x509_cert::{
     spki::{AlgorithmIdentifier, ObjectIdentifier, SubjectPublicKeyInfoOwned},
 };
 
-#[cfg(feature = "untested")]
 use zeroize::Zeroizing;
 
-#[cfg(feature = "untested")]
 use crate::consts::CB_OBJ_MAX;
 
-#[cfg(feature = "untested")]
 use rsa::{traits::PrivateKeyParts, RsaPrivateKey};
 
 /// PIV Applet Name
@@ -92,10 +89,8 @@ const TAG_ECC_POINT: u8 = 0x86;
 /// OID for ed25519 and x25519 algorithms
 pub const OID_X25519: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.3.101.110");
 
-#[cfg(feature = "untested")]
 const KEYDATA_LEN: usize = 1024;
 
-#[cfg(feature = "untested")]
 const KEYDATA_RSA_EXP: u64 = 65537;
 
 /// Slot identifiers.
@@ -545,7 +540,6 @@ impl AlgorithmId {
         Tlv::write(buf, 0x80, &[self.into()])
     }
 
-    #[cfg(feature = "untested")]
     fn get_elem_len(self) -> usize {
         match self {
             AlgorithmId::Rsa1024 => 64,
@@ -559,7 +553,6 @@ impl AlgorithmId {
         }
     }
 
-    #[cfg(feature = "untested")]
     fn get_param_tag(self) -> u8 {
         match self {
             AlgorithmId::Rsa1024
@@ -737,7 +730,6 @@ pub fn generate(
     read_public_key(algorithm, value, true)
 }
 
-#[cfg(feature = "untested")]
 fn write_key(
     yubikey: &mut YubiKey,
     slot: SlotId,
@@ -785,7 +777,6 @@ fn write_key(
 }
 
 /// The key data that makes up an RSA key.
-#[cfg(feature = "untested")]
 pub struct RsaKeyData {
     /// The secret prime `p`.
     p: Buffer,
@@ -799,7 +790,6 @@ pub struct RsaKeyData {
     qinv: Buffer,
 }
 
-#[cfg(feature = "untested")]
 impl RsaKeyData {
     /// Generates a new RSA key data set from two (randomly generated) secret primes.
     ///
@@ -856,7 +846,6 @@ impl RsaKeyData {
 /// Imports a private RSA encryption or signing key into the YubiKey.
 ///
 /// Errors if `algorithm` isn't `AlgorithmId::Rsa1024` or `AlgorithmId::Rsa2048` or `AlgorithmId::Rsa3072` or `AlgorithmId::Rsa4096`.
-#[cfg(feature = "untested")]
 pub fn import_rsa_key(
     yubikey: &mut YubiKey,
     slot: SlotId,
@@ -949,7 +938,6 @@ pub fn import_cv_key(
 /// Generate an attestation certificate for a stored key.
 ///
 /// <https://developers.yubico.com/PIV/Introduction/PIV_attestation.html>
-#[cfg(feature = "untested")]
 pub fn attest(yubikey: &mut YubiKey, key: SlotId) -> Result<Buffer> {
     let templ = [0, Ins::Attest.code(), key.into(), 0];
     let txn = yubikey.begin_transaction()?;
@@ -984,7 +972,6 @@ pub fn sign_data(
 }
 
 /// Decrypt data using a PIV key.
-#[cfg(feature = "untested")]
 pub fn decrypt_data(
     yubikey: &mut YubiKey,
     input: &[u8],

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -20,10 +20,10 @@ use crate::mgm::{DeviceConfig, DeviceInfo, Lock};
 
 const CB_PIN_MAX: usize = 8;
 
-#[cfg(feature = "untested")]
 pub(crate) enum ChangeRefAction {
     ChangePin,
     ChangePuk,
+    #[cfg(feature = "untested")]
     UnblockPin,
 }
 
@@ -205,7 +205,6 @@ impl<'tx> Transaction<'tx> {
     }
 
     /// Change the PIN.
-    #[cfg(feature = "untested")]
     pub fn change_ref(
         &self,
         action: ChangeRefAction,
@@ -222,6 +221,7 @@ impl<'tx> Transaction<'tx> {
         let templ = match action {
             ChangeRefAction::ChangePin => [0, Ins::ChangeReference.code(), 0, PIN],
             ChangeRefAction::ChangePuk => [0, Ins::ChangeReference.code(), 0, PUK],
+            #[cfg(feature = "untested")]
             ChangeRefAction::UnblockPin => [0, Ins::ResetRetry.code(), 0, PIN],
         };
 

--- a/src/yubikey.rs
+++ b/src/yubikey.rs
@@ -39,7 +39,7 @@ use crate::{
     mgm::MgmKey,
     piv,
     reader::{Context, Reader},
-    transaction::Transaction,
+    transaction::{ChangeRefAction, Transaction},
 };
 use cipher::common::getrandom::SysRng;
 use log::{error, info};
@@ -58,7 +58,6 @@ use {
         consts::{TAG_ADMIN_FLAGS_1, TAG_ADMIN_TIMESTAMP},
         metadata::AdminData,
         mgm,
-        transaction::ChangeRefAction,
         Buffer, ObjectId,
     },
     std::time::{SystemTime, UNIX_EPOCH},
@@ -548,7 +547,6 @@ impl YubiKey {
     /// Change the Personal Identification Number (PIN).
     ///
     /// The default PIN code is `123456`.
-    #[cfg(feature = "untested")]
     pub fn change_pin(&mut self, current_pin: &[u8], new_pin: &[u8]) -> Result<()> {
         {
             let txn = self.begin_transaction()?;
@@ -593,7 +591,6 @@ impl YubiKey {
     /// The PUK is part of the PIV standard that the YubiKey follows.
     ///
     /// The default PUK code is `12345678`.
-    #[cfg(feature = "untested")]
     pub fn change_puk(&mut self, current_puk: &[u8], new_puk: &[u8]) -> Result<()> {
         let txn = self.begin_transaction()?;
         txn.change_ref(ChangeRefAction::ChangePuk, current_puk, new_puk)
@@ -733,7 +730,6 @@ impl YubiKey {
     /// WARNING: this is a destructive operation which will destroy all keys!
     ///
     /// The reset function is only available when both pins are blocked.
-    #[cfg(feature = "untested")]
     pub fn reset_device(&mut self) -> Result<()> {
         let templ = [0, Ins::Reset.code(), 0, 0];
         let txn = self.begin_transaction()?;

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -3,7 +3,9 @@
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, trivial_casts, unused_qualifications)]
 
-use cipher::common::{getrandom::SysRng, Generate};
+#[cfg(feature = "untested")]
+use cipher::common::getrandom::SysRng;
+use cipher::common::Generate;
 use log::trace;
 use once_cell::sync::Lazy;
 use rsa::{pkcs1v15, RsaPublicKey};


### PR DESCRIPTION
Remove the following implementations from the untested feature as having been tested as part of a yubikey provisioning app:

- YubiKey::change_pin()
- YubiKey::change_puk()
- YubiKey::reset_device()
- CccId::set()
- ChuId::set()
- piv::attest()
- piv::decrypt_data()
- piv::import_rsa_key()
- piv::RsaKeyData (struct)

The following were also removed from the untested feature in support of the above list:

- KEYDATA_LEN
- KEYDATA_RSA_EXP
- AlgorithmId::get_elem_len
- AlgorithmId::get_param_tag
- write_key
- ChangeRefAction (enum)
- Transaction::change_ref