### PR TITLE
Switch from doc_auto_cfg to doc_cfg

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/iqlusioninc/yubikey.rs/main/img/logo-sq.png"
 )]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![forbid(unsafe_code)]
 #![warn(
     clippy::mod_module_files,


### PR DESCRIPTION
doc_auto_cfg got removed and folded into the doc_cfg feature flag.

This should fix the docs.rs build failures: https://docs.rs/crate/yubikey/0.9.0-pre.0/builds/3094946